### PR TITLE
Adição de indicação visual de hover no componente de botão e remoção do scroll 

### DIFF
--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -4,7 +4,7 @@
     width: 186px;
     height: 63px;
     
-    margin-top: 150px;
+    // margin-top: 150px;
     margin-left: 350px;
 
     background: #0880D7;
@@ -15,8 +15,9 @@
     color: white;
     font-size: 20px;
     
-    
-    margin-bottom: 10px;
+    cursor: pointer;
+
+    // margin-bottom: 10px;
 
     // display: flex;
 

--- a/src/pages/Principal/Principal.module.scss
+++ b/src/pages/Principal/Principal.module.scss
@@ -16,6 +16,7 @@
         background: #121214;
     
         width: 100%;
+        box-sizing: border-box;
        
         height: 140px;
         align-items: center;
@@ -37,14 +38,15 @@
 
         width: 100%;
         background-color: rgb(126, 182, 184);
-        margin-left: 10px;
+        padding-left: 10px;
         
         
 
         .topTopic {
 
             width: 100%;
-            height: 225px;
+            margin-top: 140px;
+            // height: 225px;
             background-color: #85e9eb;
     
             
@@ -89,7 +91,9 @@
                 display: flex;
                 background-color: #e5e5e5;
                 width: 50%;
-                height: 225px;
+                align-self: stretch;
+                align-items: center;
+                // height: 225px;
                
                 text-align: center;
                 

--- a/src/pages/Principal/index.js
+++ b/src/pages/Principal/index.js
@@ -1,5 +1,7 @@
-import Button from '../../components/Button'
 import React from 'react';
+
+import Button from '../../components/Button'
+
 import styles from './Principal.module.scss';
 
 function Principal() {


### PR DESCRIPTION
## Feito:
- Foi adicionado uma indicação visual ao sobrepor componente de botão
- Substituição de uso de height por margin, para compensar o uso do header posicionado absolutamente.